### PR TITLE
[ 이진혁 ] LayoutWrapStyle max-width 수정

### DIFF
--- a/src/components/common/Layout/style.ts
+++ b/src/components/common/Layout/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 export const LayoutWrapStyle = styled.div`
   margin: 0 auto;
-  max-width: 420px;
+  max-width: 430px;
   height: 100vh;
   border: 1px solid black;
 `;


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 현재 아이폰 14pro max가 width값이 430px인 관계로 Layout max-width를 430px으로 수정

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. LayoutWrapStyle의 max-width 값 420px -> 430px로 수정
