### PR TITLE
Modify : nextValid, pageIdx를 recoil로 관리

### DIFF
--- a/pages/select/index.tsx
+++ b/pages/select/index.tsx
@@ -12,21 +12,23 @@ import PersonalityInfo from '@src/components/select/PersonalityInfo';
 import PriceInfo from '@src/components/select/PriceInfo';
 import Onboarding from '@src/components/select/Onboarding';
 import DetailInfo from '@src/components/select/DetailInfo';
+import Next from '@src/components/common/Next';
+import { pageIdxState } from '@src/state/pageIdx';
+import { useRecoilState } from 'recoil';
 
 const Select = () => {
   const router = useRouter();
-  const [pageIdx, setPageIdx] = useState<number>(0);
-  const [nextValid, setNextValid] = useState<boolean>(false);
+  const [pageIdx, setPageIdx] = useRecoilState(pageIdxState);
 
   const pages = [
-    <ReceiverInfo key={0} setNextValid={setNextValid} />,
-    <GenderInfo key={1} setNextValid={setNextValid} />,
-    <AgeInfo key={2} setNextValid={setNextValid} />,
-    <MbtiInfo key={3} setNextValid={setNextValid} />,
-    <PersonalityInfo key={4} setNextValid={setNextValid} />,
-    <PriceInfo key={5} setNextValid={setNextValid} />,
-    <Onboarding key={6} setNextValid={setNextValid} />,
-    <DetailInfo key={7} setNextValid={setNextValid} />,
+    <ReceiverInfo key={0} />,
+    <GenderInfo key={1} />,
+    <AgeInfo key={2} />,
+    <MbtiInfo key={3} />,
+    <PersonalityInfo key={4} />,
+    <PriceInfo key={5} />,
+    <Onboarding key={6} />,
+    <DetailInfo key={7} />,
   ];
 
   const handleClickPrev = () => {
@@ -61,7 +63,7 @@ const Select = () => {
         <StContents>{pages[pageIdx]}</StContents>
         <StFooter>
           {pageIdx + 1 !== pages.length ? (
-            <StNextBtn onClick={handleClickNext}>다음</StNextBtn>
+            <Next handleClickNext={handleClickNext} />
           ) : (
             <StNextBtn onClick={handleClickSubmit}>제출</StNextBtn>
           )}

--- a/src/components/common/Next.tsx
+++ b/src/components/common/Next.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import { nextValidState } from '@src/state/nextValid';
+import { useRecoilValue } from 'recoil';
 
 interface Props {
   handleClickNext: () => void;
 }
 
 const Next = ({ handleClickNext }: Props) => {
+  const nextValid = useRecoilValue(nextValidState);
   return (
-    <StNext nextValid={true} disabled={false} onClick={handleClickNext}>
+    <StNext nextValid={nextValid} disabled={!nextValid} onClick={handleClickNext}>
       다음
     </StNext>
   );

--- a/src/components/select/AgeInfo.tsx
+++ b/src/components/select/AgeInfo.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const AgeInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
-
+const AgeInfo = () => {
   return (
     <StAgeInfo>
       <StHeader>

--- a/src/components/select/DetailInfo.tsx
+++ b/src/components/select/DetailInfo.tsx
@@ -1,8 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const DetailInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
+const DetailInfo = () => {
   return (
     <StDetailInfo>
       <StHeader>

--- a/src/components/select/GenderInfo.tsx
+++ b/src/components/select/GenderInfo.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const GenderInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
-
+const GenderInfo = () => {
   return (
     <StGenderInfo>
       <StHeader>

--- a/src/components/select/MbtiInfo.tsx
+++ b/src/components/select/MbtiInfo.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const MbtiInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
-
+const MbtiInfo = () => {
   return (
     <StMbtiInfo>
       <StHeader>

--- a/src/components/select/Onboarding.tsx
+++ b/src/components/select/Onboarding.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const Onboarding = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
-
+const Onboarding = () => {
   return (
     <StOnboarding>
       <StHeader>

--- a/src/components/select/PersonalityInfo.tsx
+++ b/src/components/select/PersonalityInfo.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const PersonalityInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
-
+const PersonalityInfo = () => {
   return (
     <StPersinalityInfo>
       <StHeader>

--- a/src/components/select/PriceInfo.tsx
+++ b/src/components/select/PriceInfo.tsx
@@ -1,9 +1,7 @@
 import styled from '@emotion/styled';
 import Headline from '../common/Headline';
 
-const PriceInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
-
+const PriceInfo = () => {
   return (
     <StPriceInfo>
       <StHeader>

--- a/src/components/select/ReceiverInfo.tsx
+++ b/src/components/select/ReceiverInfo.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
+import { receiverState } from '@src/state/receiver';
+import { useRecoilState } from 'recoil';
 import Headline from '../common/Headline';
 
-const ReceiverInfo = (props: SetStateProps<boolean>) => {
-  const { setNextValid } = props;
+const ReceiverInfo = () => {
+  const [receiver, setReceiver] = useRecoilState(receiverState);
 
   return (
     <StRecieverInfo>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,3 @@
-interface SetStateProps<T> {
-  setNextValid: Dispatch<SetStateAction<T>>;
-}
 interface Iprice {
   start: number;
   end: number;

--- a/src/state/nextValid.ts
+++ b/src/state/nextValid.ts
@@ -1,0 +1,38 @@
+import { selector } from 'recoil';
+import { pageIdxState } from './pageIdx';
+import { genderState } from './gender';
+import { ageState } from './age';
+import { mbtiState } from './mbti';
+import { personalityState } from './presonality';
+import { priceState } from './price';
+import { relationState } from './relation';
+import { receiverState } from './receiver';
+
+export const nextValidState = selector({
+  key: 'nextValidState',
+  get: ({ get }) => {
+    const pageIdx = get(pageIdxState);
+    const receiver = get(receiverState);
+    const gender = get(genderState);
+    const age = get(ageState);
+    const mbti = get(mbtiState);
+    const personality = get(personalityState);
+    const price = get(priceState);
+
+    switch (pageIdx) {
+      case 0:
+        return receiver > 0;
+      case 1:
+        return gender > 0;
+      case 2:
+        return age > 0;
+      case 3:
+        return mbti > 0;
+      case 4:
+        return personality > 0;
+      default:
+        return true;
+    }
+  },
+});
+// Todo : 페이지 확정되면 case 정리 / 유지보수에 더 좋은 방법 생각해보기

--- a/src/state/pageIdx.ts
+++ b/src/state/pageIdx.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const pageIdxState = atom<number>({
+  key: 'pageIdxState',
+  default: 0,
+});

--- a/src/state/receiver.ts
+++ b/src/state/receiver.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const receiverState = atom({
+  key: 'receiverState',
+  default: 0,
+});


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- nextValid 를 recoil selector를 통해 return해주도록 변경

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- pageIdx 를 recoil atom으로 변경
- nextValid를 recoil selector로 변경

## :: 특이사항
- nextValid를 현재 switch case를 통해 분기처리를 하였는데 더 좋은 방법이 있는지 논의 필요
- page 확정되는대로 nextValid의 case 추가 필요