### PR TITLE
Headline 컴포넌트 구현 완료

### DIFF
--- a/src/components/common/Headline.tsx
+++ b/src/components/common/Headline.tsx
@@ -2,31 +2,34 @@ import styled from '@emotion/styled';
 import React from 'react';
 
 interface Props {
-  keyword?: string;
   text: string;
 }
 
-const Headline = ({ keyword, text }: Props) => {
+const Headline = ({ text }: Props) => {
+  const firstText: string = text.split('/')[0];
+  const secondText: string = text.split('/')[2];
+  const keywordText: string = text.split('/')[1];
+
   return (
     <StHeadline>
-      <StText>
-        <StKeyword>{keyword}</StKeyword> {text}
-      </StText>
+      <StText>{firstText}</StText>
+      <StKeyword>{keywordText}</StKeyword>
+      <StText>{secondText}</StText>
     </StHeadline>
   );
 };
 
 const StHeadline = styled.div`
   width: 100%;
-`;
-
-const StText = styled.p`
-  font-size: 20px;
   text-align: center;
 `;
 
+const StText = styled.span`
+  font-size: 20px;
+`;
+
 const StKeyword = styled.span`
-  color: red;
+  color: #456f87;
   font-size: 20px;
   font-weight: 600;
 `;

--- a/src/components/select/AgeInfo.tsx
+++ b/src/components/select/AgeInfo.tsx
@@ -5,7 +5,7 @@ const AgeInfo = () => {
   return (
     <StAgeInfo>
       <StHeader>
-        <Headline text="상대방의 나이는 어떻게 되나요?" />
+        <Headline text="상대방의 /나이/는 어떻게 되나요?" />
       </StHeader>
     </StAgeInfo>
   );

--- a/src/components/select/GenderInfo.tsx
+++ b/src/components/select/GenderInfo.tsx
@@ -5,7 +5,7 @@ const GenderInfo = () => {
   return (
     <StGenderInfo>
       <StHeader>
-        <Headline text="상대방의 성별을 알려주세요." />
+        <Headline text="상대방의 /성별/을 알려주세요." />
       </StHeader>
     </StGenderInfo>
   );

--- a/src/components/select/MbtiInfo.tsx
+++ b/src/components/select/MbtiInfo.tsx
@@ -5,7 +5,7 @@ const MbtiInfo = () => {
   return (
     <StMbtiInfo>
       <StHeader>
-        <Headline text="상대방의 MBTI를 알고 있나요?" />
+        <Headline text="상대방의 /MBTI/를 알고 있나요?" />
       </StHeader>
     </StMbtiInfo>
   );

--- a/src/components/select/PersonalityInfo.tsx
+++ b/src/components/select/PersonalityInfo.tsx
@@ -5,7 +5,7 @@ const PersonalityInfo = () => {
   return (
     <StPersinalityInfo>
       <StHeader>
-        <Headline text="그럼 평소의 성격은 어떤가요?" />
+        <Headline text="그럼 /평소의 성격/은 어떤가요?" />
       </StHeader>
     </StPersinalityInfo>
   );

--- a/src/components/select/PriceInfo.tsx
+++ b/src/components/select/PriceInfo.tsx
@@ -5,7 +5,7 @@ const PriceInfo = () => {
   return (
     <StPriceInfo>
       <StHeader>
-        <Headline text="선물의 가격대는 어느 정도가 좋은가요?" />
+        <Headline text="/선물의 가격대/는 어느 정도가 좋은가요?" />
       </StHeader>
     </StPriceInfo>
   );

--- a/src/components/select/ReceiverInfo.tsx
+++ b/src/components/select/ReceiverInfo.tsx
@@ -9,7 +9,7 @@ const ReceiverInfo = () => {
   return (
     <StRecieverInfo>
       <StHeader>
-        <Headline text="누구에게 줄 선물인가요?" />
+        <Headline text="/누구/에게 줄 선물인가요?" />
       </StHeader>
     </StRecieverInfo>
   );


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- Headline 컴포넌트 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. Headline 컴포넌트 구현 
- string 형태인 text를 props로 받음
- text 안에서 키워드는 앞뒤에 /로 감싸 headline 컴토넌트 안에서 split을 통해 배열로 나눔
- 배열의 0, 1, 2번째 항목을 각각 변수로 선언하고 사용
