### PR TITLE
ADD : 계절 페이지 구현 완료

### DIFF
--- a/pages/select/index.tsx
+++ b/pages/select/index.tsx
@@ -14,6 +14,7 @@ import RelationInfo from '@src/components/select/RelationInfo/RelationInfo';
 import TimeInfo from '@src/components/select/TimeInfo';
 import Next from '@src/components/common/Next';
 import HobbyInfo from '@src/components/select/HobbyInfo';
+import SeasonInfo from '@src/components/select/SeasonInfo';
 import EventInfo from '@src/components/select/EventInfo';
 import { pageIdxState } from '@src/state/pageIdx';
 import { useRecoilState } from 'recoil';
@@ -33,6 +34,7 @@ const Select = () => {
     <RelationInfo key={7} />,
     <TimeInfo key={8} />,
     <HobbyInfo key={9} />,
+    <SeasonInfo key={10} />,
     <EventInfo key={11} />,
   ];
 

--- a/src/components/select/HobbyInfo.tsx
+++ b/src/components/select/HobbyInfo.tsx
@@ -11,14 +11,17 @@ const HobbyInfo = () => {
       return [...hobbys, hobby];
     });
   };
+
   const deselectHobby = (hobby: number) => {
     setHobby((hobbys) => {
       return [...hobbys].filter((key) => key !== hobby);
     });
   };
+
   const handleSelect = (key: number): void => {
     hobby.includes(key) ? deselectHobby(key) : selectHobby(key);
   };
+
   return (
     <StHobbyInfo>
       <StHeader>

--- a/src/components/select/SeasonInfo.tsx
+++ b/src/components/select/SeasonInfo.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+import { seasonState } from '@src/state/season';
+import { useRecoilState } from 'recoil';
+import Headline from '../common/Headline';
+import Option from '../common/Option';
+
+const SeasonInfo = () => {
+  const [season, setSeason] = useRecoilState(seasonState);
+
+  const selectSeason = (season: number) => {
+    setSeason((seasons) => {
+      return [...seasons, season];
+    });
+  };
+
+  const deselectSeason = (season: number) => {
+    setSeason((seasons) => {
+      return [...seasons].filter((key) => key !== season);
+    });
+  };
+
+  const handleSelect = (key: number): void => {
+    if (key === 5 && !season.includes(key)) return setSeason([key]);
+
+    if (season.includes(5) && season.length > 0) deselectSeason(5);
+
+    season.includes(key) ? deselectSeason(key) : selectSeason(key);
+  };
+
+  return (
+    <StSeasonInfo>
+      <StHeader>
+        <Headline text="/어떤 계절/에 선물 할껀가요? " />
+      </StHeader>
+      <StContents>
+        <StBtnWrap>
+          {OPTION.map(({ key, option }) => (
+            <Option key={key} text={option} selected={season.includes(key)} onClick={() => handleSelect(key)} />
+          ))}
+        </StBtnWrap>
+      </StContents>
+    </StSeasonInfo>
+  );
+};
+
+const OPTION: IOption[] = [
+  { key: 1, option: '봄' },
+  { key: 2, option: '여름' },
+  { key: 3, option: '가을' },
+  { key: 4, option: '겨울' },
+  { key: 5, option: '아무때나' },
+];
+
+const StSeasonInfo = styled.div`
+  width: 100%;
+`;
+
+const StHeader = styled.div`
+  width: 100%;
+`;
+
+const StContents = styled.div`
+  margin-top: 20px;
+  width: 100%;
+`;
+
+const StBtnWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export default SeasonInfo;

--- a/src/state/nextValid.ts
+++ b/src/state/nextValid.ts
@@ -8,6 +8,7 @@ import { priceState } from './price';
 import { relationState } from './relation';
 import { receiverState } from './receiver';
 import { hobbyState } from './hobby';
+import { seasonState } from './season';
 import { timeState } from './time';
 
 export const nextValidState = selector({
@@ -22,6 +23,7 @@ export const nextValidState = selector({
     const relation = get(relationState);
     const price = get(priceState);
     const hobby = get(hobbyState);
+    const season = get(seasonState);
     const time = get(timeState);
 
     switch (pageIdx) {
@@ -41,6 +43,8 @@ export const nextValidState = selector({
         return time > 0;
       case 9:
         return hobby.length > 0;
+      case 10:
+        return season.length > 0;
       default:
         return true;
     }

--- a/src/state/relation.ts
+++ b/src/state/relation.ts
@@ -5,36 +5,36 @@ export const relationState = atom<number>({
   default: 0,
 });
 
-// const RELATION_STRING = [
-//   '남자친구',
-//   '여자친구',
-//   '커플',
-//   '부모님',
-//   '아빠',
-//   '엄마',
-//   '친구',
-//   '지인',
-//   '이웃',
-//   '장인어른',
-//   '장모님',
-//   '할아버지',
-//   '할머니',
-//   '남편',
-//   '아내',
-//   '아들',
-//   '딸',
-//   '선생님',
-//   '직장동료',
-//   '상사',
-//   '직원',
-//   '친척',
-//   '조카',
-// ];
+const RELATION_STRING = [
+   '남자친구',
+   '여자친구',
+   '커플',
+   '부모님',
+   '아빠',
+   '엄마',
+   '친구',
+   '지인',
+   '이웃',
+   '장인어른',
+   '장모님',
+   '할아버지',
+   '할머니',
+   '남편',
+   '아내',
+   '아들',
+   '딸',
+   '선생님',
+   '직장동료',
+   '상사',
+   '직원',
+   '친척',
+   '조카',
+ ];
 
-// export const relationStringState = selector({
-//   key: 'relationStringState',
-//   get: ({ get }) => {
-//     const relation = get(relationState);
-//     return RELATION_STRING[relation - 1];
-//   },
-// });
+ export const relationStringState = selector({
+   key: 'relationStringState',
+   get: ({ get }) => {
+     const relation = get(relationState);
+     return RELATION_STRING[relation - 1];
+   },
+ });

--- a/src/state/relation.ts
+++ b/src/state/relation.ts
@@ -5,36 +5,36 @@ export const relationState = atom<number>({
   default: 0,
 });
 
-const RELATION_STRING = [
-  '남자친구',
-  '여자친구',
-  '커플',
-  '부모님',
-  '아빠',
-  '엄마',
-  '친구',
-  '지인',
-  '이웃',
-  '장인어른',
-  '장모님',
-  '할아버지',
-  '할머니',
-  '남편',
-  '아내',
-  '아들',
-  '딸',
-  '선생님',
-  '직장동료',
-  '상사',
-  '직원',
-  '친척',
-  '조카',
-];
+// const RELATION_STRING = [
+//   '남자친구',
+//   '여자친구',
+//   '커플',
+//   '부모님',
+//   '아빠',
+//   '엄마',
+//   '친구',
+//   '지인',
+//   '이웃',
+//   '장인어른',
+//   '장모님',
+//   '할아버지',
+//   '할머니',
+//   '남편',
+//   '아내',
+//   '아들',
+//   '딸',
+//   '선생님',
+//   '직장동료',
+//   '상사',
+//   '직원',
+//   '친척',
+//   '조카',
+// ];
 
-export const relationStringState = selector({
-  key: 'relationStringState',
-  get: ({ get }) => {
-    const relation = get(relationState);
-    return RELATION_STRING[relation - 1];
-  },
-});
+// export const relationStringState = selector({
+//   key: 'relationStringState',
+//   get: ({ get }) => {
+//     const relation = get(relationState);
+//     return RELATION_STRING[relation - 1];
+//   },
+// });

--- a/src/state/season.ts
+++ b/src/state/season.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const seasonState = atom<number[]>({
+  key: 'seasonState',
+  default: [],
+});


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 계절 페이지 구현

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 계절 페이지 구현
- 선택한 옵션의 key를 배열에 넣는 함수 selectSeason(), 선택된 옵션을 한 번 더 눌렀을  때 배열에서 없애는 deselectSeason()을 구현
- 버튼을 클릭시 season 배열을 include로 key를 갖고 있는지 없는지에 따라 삼항연산자로  selectSeason와 deselectSeason 를 상황에 따라 적용되도록 구현
- 다른 계절과 함께 아무때나 버튼을 클릭시 기존에 선택되었던 다른 계절들은 모두 배열에서 삭제, 만약 아무때나 버튼이 활성화되어 있는 상태에서 다른 계절을 클릭 시 아무때나를 배열에서 삭제
