### PR TITLE
Fix : 썸네일 이미지 url이 유효하지 않을 때 기본 이미지로 교체하는 작업 완료

### DIFF
--- a/src/components/result/Recommend/Product.tsx
+++ b/src/components/result/Recommend/Product.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
 import { currentProductState } from '@src/state/currentProduct';
@@ -15,6 +15,7 @@ interface IProps {
 const Product = ({ product, index }: IProps) => {
   const router = useRouter();
   const setCurrentProduct = useSetRecoilState(currentProductState);
+  const [isError, setisError] = useState<boolean>(false);
 
   const { id: productId, product_url: url, product_name, product_price, product_review_count, thumbnail } = product;
 
@@ -30,7 +31,13 @@ const Product = ({ product, index }: IProps) => {
       </StBadgeWrap>
       <StImgWrap>
         {thumbnail ? (
-          <StImg src={thumbnail} alt={product_name} />
+          <StImg
+            onError={() => {
+              setisError(true);
+            }}
+            src={isError ? DefaultImg.src : thumbnail}
+            alt={product_name}
+          />
         ) : (
           <StDefault src={DefaultImg} alt={product_name} fill />
         )}


### PR DESCRIPTION
## :: 📌 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 🚩 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 썸네일 이미지 url이 유효하지 않을 때 기본 이미지로 교체하는 작업

<br />

## :: 🧾 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 썸네일 이미지 url이 유효하지 않을 때 기본 이미지로 교체하는 작업 
- img 태그의 onError 이벤트를 활용하여 thumbnail url은 서버로부터 내려오지만 유효하지 않을 경우를 대비해 onError 이벤츠와 useState로 구현 완료